### PR TITLE
chore: dbmate dbmigration 설정 파일 nickname varchar 개수 제한 수정

### DIFF
--- a/db/migrations/20230911064620_create_user_table.sql
+++ b/db/migrations/20230911064620_create_user_table.sql
@@ -1,7 +1,7 @@
 -- migrate:up
 CREATE TABLE `users` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `nickname` varchar NOT NULL UNIQUE,
+  `nickname` varchar(255) NOT NULL UNIQUE,
   `email` varchar(50) NOT NULL UNIQUE,
   `password` varchar(500) NOT NULL,
   `profile_image` text NOT NULL,


### PR DESCRIPTION
### hotfix
- dbmate dbmigration 설정 파일 nickname varchar 개수 제한 수정
